### PR TITLE
On failover, associate elastic-ip to interface-id instead of instance-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,22 @@ High availability management of EC2 VPC routes based on Serf. Serf keeps track
 of when NAT instances come and go and will pass those events on to the
 `nat-handler.py` script. When new NAT instances join the cluster (which could
 also mean that the instance itself is joining some other cluster) script will
-take its default route as specified in `/etc/nat.conf`. When NAT instances fail
-or leave the cluster the script will take their default route so that all
-routes are always being served by somebody.
+allow running instances to take the default route its eth0 interface where this
+interface will always have a public ip which connects all instances to the internet.
+However, when NAT instances fail or leave the cluster the script will replace the route
+with any running instance eth0 interface. This ensures all
+routes are always being served by some instance.
+
+
+More on failover
+=================
+Each instance would have 3 network interfaces eth0, eth1 and eth2 to begin with where eth0
+will always have a public ip and eth1 w.r.t all alive nat instances will have an elastic ip
+attached to it. eth2 on the other hand is used during failover where any alive nat instance will associate the
+elastic ip of a failed instance onto its own eth2 interface. When the failed instance comes back
+up (or another instance in the same availability zone) it claims back the elastic ip onto its eth1 interface.
+Thus in this way, during failovers, elastic ips are always served by some running instances.
+
 
 The script only operates in quorum, that is, when it's in the same cluster as
 at least half of all the NAT instances. Using quorum helps solve race conditions during netsplits.

--- a/nat-handler.py
+++ b/nat-handler.py
@@ -23,14 +23,20 @@ This script makes certain assumptions:
 
         {
             "eu-west-1a": {
+                "eth1_id": "eni-abc123",
+                "eth2_id": "eni-abc456",
                 "route_table_id": "rtb-0e0ed06b",
                 "elastic_ip_allocation_id": "eipalloc-cc618fa9"
             },
             "eu-west-1b": {
+                "eth1_id": "eni-def123",
+                "eth2_id": "eni-def456",
                 "route_table_id": "rtb-090ed06c",
                 "elastic_ip_allocation_id": "eipalloc-c5618fa0",
             },
             "eu-west-1c": {
+                "eth1_id": "eni-ghi123",
+                "eth2_id": "eni-ghi456",
                 "route_table_id": "rtb-080ed06d",
                 "elastic_ip_allocation_id": "eipalloc-c4618fa1",
             }
@@ -75,6 +81,17 @@ class Config(object):
             return entry.get('elastic_ip_allocation_id')
         return None
 
+    def eth1_id(self, az):
+        entry = self.config_dict[az]
+        if isinstance(entry, dict):
+            return entry.get('eth1_id')
+        return None
+
+    def eth2_id(self, az):
+        entry = self.config_dict[az]
+        if isinstance(entry, dict):
+            return entry.get('eth2_id')
+        return None
 
 
 class Rerouter(object):
@@ -94,23 +111,43 @@ class Rerouter(object):
     def current_region(self):
         return self.current_az[:-1]
 
+    @property
+    def eth0_id(self):
+        ec2 = connect_to_ec2(self.current_region)
+        instance = ec2.get_only_instances(instance_ids=[self.current_instance_id])[0]
+        eth0 = [i for i in instance.interfaces if i.id not in [self.eth1_id, self.eth2_id]]
+        return eth0[0].id
+
+    @property
+    def eth1_id(self):
+        return self.config.eth1_id(self.current_az)
+
+    @property
+    def eth2_id(self):
+        return self.config.eth2_id(self.current_az)
+
     def take_route(self, az):
         route_table_id = self.config.route_table_id(az)
         vpc = connect_to_vpc(self.current_region)
-        vpc.replace_route(route_table_id, '0.0.0.0/0', instance_id=self.current_instance_id)
+        vpc.replace_route(route_table_id, '0.0.0.0/0', interface_id=self.eth0_id)
 
     def take_elastic_ip(self, az):
+        ''' EIP fails over onto interface id if provided or instance id '''
         elastic_ip_allocation_id = self.config.elastic_ip_allocation_id(az)
         if elastic_ip_allocation_id:
             ec2 = connect_to_ec2(self.current_region)
-            ec2.associate_address(
-                    self.current_instance_id, allocation_id=elastic_ip_allocation_id)
+            interface_id = self.eth1_id if az == self.current_az else self.eth2_id
+            if interface_id:
+                ec2.associate_address(network_interface_id=interface_id,
+                                      allocation_id=elastic_ip_allocation_id, allow_reassociation=True)
+            else:
+                ec2.associate_address(self.current_instance_id,
+                                      allocation_id=elastic_ip_allocation_id, allow_reassociation=True)
 
     def __call__(self, az=None):
         az = az or self.current_az
         self.take_route(az)
         self.take_elastic_ip(az)
-
 
 
 class Quorum(object):

--- a/tests.py
+++ b/tests.py
@@ -14,34 +14,50 @@ class TestConfig(object):
     def test_complex_with_eip(self):
         jsondata = {
             'eu-west-1a': {
+                'eth1_id': 'eni-abc123',
+                'eth2_id': 'eni-abc456',
                 'route_table_id': 'rtb-0e0ed06b',
                 'elastic_ip_allocation_id': 'eipalloc-cc618fa9'
             },
             'eu-west-1b': {
+                'eth1_id': 'eni-def123',
+                'eth2_id': 'eni-def456',
                 'route_table_id': 'rtb-090ed06c',
                 'elastic_ip_allocation_id': 'eipalloc-c5618fa0',
             },
             'eu-west-1c': {
+                'eth1_id': 'eni-ghi123',
+                'eth2_id': 'eni-ghi456',
                 'route_table_id': 'rtb-080ed06d',
                 'elastic_ip_allocation_id': 'eipalloc-c4618fa1',
             }
         }
         conf = nat_handler.Config(jsondata)
         assert conf.route_table_id('eu-west-1a') == 'rtb-0e0ed06b'
+        assert conf.eth1_id('eu-west-1a') == 'eni-abc123'
+        assert conf.eth2_id('eu-west-1a') == 'eni-abc456'
         assert conf.elastic_ip_allocation_id('eu-west-1a') == 'eipalloc-cc618fa9'
 
     def test_complex_without_eip(self):
         jsondata = {
             'eu-west-1a': {
+                'eth1_id': 'eni-abc123',
+                'eth2_id': 'eni-abc456',
                 'route_table_id': 'rtb-0e0ed06b',
             },
             'eu-west-1b': {
+                'eth1_id': 'eni-def123',
+                'eth2_id': 'eni-def456',
                 'route_table_id': 'rtb-090ed06c',
             },
             'eu-west-1c': {
+                'eth1_id': 'eni-ghi123',
+                'eth2_id': 'eni-ghi456',
                 'route_table_id': 'rtb-080ed06d',
             }
         }
         conf = nat_handler.Config(jsondata)
         assert conf.route_table_id('eu-west-1a') == 'rtb-0e0ed06b'
+        assert conf.eth1_id('eu-west-1a') == 'eni-abc123'
+        assert conf.eth2_id('eu-west-1a') == 'eni-abc456'
         assert conf.elastic_ip_allocation_id('eu-west-1a') == None


### PR DESCRIPTION
This PR does the following:
Implements new failover of EIP onto eth1 or eth2 interfaces

Each nat instance would be configured with three network interfaces (eth0, eth1 and eth2)
- eth0 will be untouched and will always have a public ip. This would be used in subnet routing onto the internet for the current region the instance is running in. During failover, it would also assume route of a subnet for which the nat instance in that AZ is not running anymore.
- eth1 will be used to associate EIP onto it so requests coming in can be served
- eth2 will be used as standby during failover where it will re-associate the EIP of a failed/ shutdown/ rebooted instance it was then serving. Thus, the EIP would always be reachable and serve requests from some running instance.

And also allows the new / rebooted instance to (re)claims the EIP for the availability zone it is configured for onto eth1.

Dependency:
https://github.com/wrapp/whaleshark/pull/29
